### PR TITLE
fix: #autostart without line num

### DIFF
--- a/txt2nextbasic.py
+++ b/txt2nextbasic.py
@@ -86,6 +86,8 @@ def main():
             if line:
                 # Comments and directives aren't parsed
                 if line[0] != '#':
+                    if load_addr == 0: # if they used #autostart, grab the next line number
+                        load_addr, _ = extract_linenumber(line)
                     arr_line = proc_basic(line)
                     if arr_line:
                         basic_data.append(arr_line)  # Parse BASIC


### PR DESCRIPTION
The autostart was missing when it used the `#autostart` (no line number) syntax - it should point to the next available line number, otherwise autostart didn't appear to work.

Python isn't my first (or second, or third) language, so I hope this is okay. I've tested it locally and compared to the generated files from the .txt2bas command on the Next (and in cspect) to confirm the bytes are loaded up correctly and this looks to be the right change.